### PR TITLE
Fixes [ellipsis-content] not detecting an empty string as a change

### DIFF
--- a/src/lib/directives/ellipsis.directive.ts
+++ b/src/lib/directives/ellipsis.directive.ts
@@ -35,7 +35,7 @@ export class EllipsisDirective {
   private applyOnWindowResize = false;
 
   /**
-   * Remove function for the currently registered click listener 
+   * Remove function for the currently registered click listener
    * on the link `this.ellipsisCharacters` are wrapped in.
    */
   private destroyMoreClickListener: () => void;
@@ -134,7 +134,7 @@ export class EllipsisDirective {
    * and re-render
    */
   ngOnChanges() {
-    if (!this.elem || !this.ellipsisContent || this.originalText == this.ellipsisContent) {
+    if (!this.elem || this.ellipsisContent === undefined || this.originalText === this.ellipsisContent) {
       return;
     }
 
@@ -171,7 +171,7 @@ export class EllipsisDirective {
     if (typeof(this.resizeDetectionStrategy) == 'undefined') {
       this.resizeDetectionStrategy = '';
     }
-    
+
     switch (this.resizeDetectionStrategy) {
       case 'window':
         this.applyOnWindowResize = true;


### PR DESCRIPTION
I had an issue with [ellipsis-content] not detecting a change when the changed value is empty.

My specific use case is a form field with a live preview. The live preview is using ngx-ellipsis. If I clear the contents of the form field, the preview doesn't get updated (due to an empty string being falsy in JavaScript).