### PR TITLE
Protect escapeHtml against null or undefined arg

### DIFF
--- a/projects/ngx-ellipsis/src/lib/directives/ellipsis.directive.ts
+++ b/projects/ngx-ellipsis/src/lib/directives/ellipsis.directive.ts
@@ -127,14 +127,16 @@ export class EllipsisDirective implements OnChanges, OnDestroy, AfterViewInit {
    * @return       escaped string
    */
   private static escapeHtml(unsafe: string): string {
-    unsafe = unsafe
+    if (unsafe === undefined || unsafe === null) {
+      return '';
+    }
+
+    return String(unsafe)
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#039;');
-
-    return unsafe;
   }
 
   /**

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,17 @@
+.samples {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.sample {
+  width: 200px;
+  height: 200px;
+  border: dashed 2px gray;
+  margin: 30px;
+}
+
+.small {
+  width: 100px;
+  height: 20px;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,8 @@
 <h1>Welcome to ngx-ellipsis-demo!</h1>
-<div ellipsis style="width: 200px; height: 200px;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
+<div class="samples">
+  <div class="sample" ellipsis>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</div>
+  <div class="sample" ellipsis [ellipsis-content]="longText"></div>
+  <div class="sample small" ellipsis [ellipsis-content]="number"></div>
+  <div class="sample" ellipsis [ellipsis-content]="undefinedText"></div>
+  <div class="sample" ellipsis [ellipsis-content]="nullText"></div>
+</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,4 +7,13 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'ngx-ellipsis-demo';
+  longText = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna \
+              aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea\
+              takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy \
+              eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo \
+              dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
+  // the next variables would cause an error in the htmlEscape method before the new checks.
+  number = 12.4564564564564564;
+  undefinedText: string = undefined;
+  nullText: string = null;
 }


### PR DESCRIPTION
Ensure that `unsafe` is actually a string before trying to do a string replace.
This overcomes the problems where unsafe is null or undefined or even a number.

I've come across some cases where the `unsafe` argument is undefined or even a number depending how the user is using this module.

I'm not sure `escapeHtml` is the correct for this fix. Maybe it should be done sooner in the directive and this function kept as is. What do you think?