### PR TITLE
Provide a way to find out if text overflows and ellipsis presence

### DIFF
--- a/projects/ngx-ellipsis/src/lib/directives/ellipsis.directive.ts
+++ b/projects/ngx-ellipsis/src/lib/directives/ellipsis.directive.ts
@@ -438,11 +438,10 @@ export class EllipsisDirective implements OnChanges, OnDestroy, AfterViewInit {
     }
   }
 
-
   /**
    * Whether the text is exceeding the element's boundaries or not
    */
-  private get isOverflowing(): boolean {
+  public get isOverflowing(): boolean {
     // Enforce hidden overflow (required to compare client width/height with scroll width/height)
     const currentOverflow = this.elem.style.overflow;
     if (!currentOverflow || currentOverflow === 'visible') {


### PR DESCRIPTION
Implementing ngx-ellipsis, we came across a requirement to show tooltip on mouse over only when ellipsis are not present or text overflow.

Right now we don't have any way which pragmatically indicate the status of ellipsis presence.

There are multiple ways we can provide this access.
1. Make isOverflowing method public so that user can access element overflow state using ViewChildren or ViewChild in angular component.
2. Provide output event emitter that will update flag state to outer component.

This MR is just to make isOverflowing method public as it would create a way for user to check its state from ViewChild instance in angular component.

